### PR TITLE
Fix state sync issues and improve reliability

### DIFF
--- a/custom_components/micro_air_easytouch/__init__.py
+++ b/custom_components/micro_air_easytouch/__init__.py
@@ -36,7 +36,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             _LOGGER.debug("Received BLE advertisement from %s: %s", address, service_info)
             data._start_update(service_info)
 
-    hass.bus.async_listen("bluetooth_service_info", _handle_bluetooth_update)
+    # Store the cancel callback to properly clean up on unload
+    cancel_listener = hass.bus.async_listen("bluetooth_service_info", _handle_bluetooth_update)
+    hass.data[DOMAIN][entry.entry_id]["cancel_listener"] = cancel_listener
 
     # Register services
     await async_register_services(hass)
@@ -47,7 +49,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
-        hass.data[DOMAIN].pop(entry.entry_id)
+        entry_data = hass.data[DOMAIN].pop(entry.entry_id)
+        # Cancel the bluetooth listener to prevent memory leak
+        if "cancel_listener" in entry_data:
+            entry_data["cancel_listener"]()
         # Unregister services
         await async_unregister_services(hass)
     return unload_ok

--- a/custom_components/micro_air_easytouch/climate.py
+++ b/custom_components/micro_air_easytouch/climate.py
@@ -112,6 +112,7 @@ class MicroAirEasyTouchClimate(ClimateEntity):
             model="Thermostat",
         )
         self._state = {}
+        self._last_known_hvac_mode: HVACMode | None = None
 
     @property
     def icon(self) -> str:
@@ -146,6 +147,13 @@ class MicroAirEasyTouchClimate(ClimateEntity):
                     # Preserve existing state if fetch returns empty/partial data
                     if new_state:
                         self._state = new_state
+                        # Track last active mode so transient OFF readings don't
+                        # lose the real state (used as fallback in hvac_mode).
+                        mode_num = new_state.get("current_mode_num")
+                        if mode_num is not None and mode_num != 0:
+                            self._last_known_hvac_mode = EASY_MODE_TO_HA_MODE.get(
+                                mode_num, self._last_known_hvac_mode
+                            )
                         _LOGGER.debug("State fetched: %s", self._state)
                         self.async_write_ha_state()
                 else:
@@ -188,18 +196,22 @@ class MicroAirEasyTouchClimate(ClimateEntity):
     @property
     def hvac_mode(self) -> HVACMode:
         """Return hvac operation mode."""
-        # Check if the device is actually powered off via PRM flags
-        # PRM contains 7 when off, 15 when on
+        # current_mode_num (info[15]) is the authoritative live operating mode —
+        # 0 means off, non-zero means running in that mode (3=cool_on, 5=heat_on, …).
+        # Check it first so that a transient PRM "off" flag (value 7 in param) during
+        # a BLE connection/transition does not override a running mode.
+        current_mode_num = self._state.get("current_mode_num")
+        if current_mode_num is not None:
+            if current_mode_num == 0:
+                return HVACMode.OFF
+            return EASY_MODE_TO_HA_MODE.get(current_mode_num, HVACMode.OFF)
+
+        # No current_mode_num yet (state not populated before first poll).
+        # Fall back to PRM flags, then last known mode.
         if self._state.get("off") and not self._state.get("on"):
             return HVACMode.OFF
-        # current_mode_num (info[15]) reflects the actual operating state
-        # including active states: 3=cool_on, 5=heat_on
-        # mode_num (info[10]) only reflects the last configured mode, not power state
-        current_mode_num = self._state.get("current_mode_num")
-        if current_mode_num == 0 and self._state.get("off"):
-            return HVACMode.OFF
-        if current_mode_num is not None:
-            return EASY_MODE_TO_HA_MODE.get(current_mode_num, HVACMode.OFF)
+        if self._last_known_hvac_mode is not None:
+            return self._last_known_hvac_mode
         return HVACMode.OFF
 
     @property

--- a/custom_components/micro_air_easytouch/climate.py
+++ b/custom_components/micro_air_easytouch/climate.py
@@ -188,6 +188,15 @@ class MicroAirEasyTouchClimate(ClimateEntity):
     @property
     def hvac_mode(self) -> HVACMode:
         """Return hvac operation mode."""
+        # Check if the device is actually powered off via PRM flags
+        # PRM contains 7 when off, 15 when on
+        if self._state.get("off") and not self._state.get("on"):
+            return HVACMode.OFF
+        # current_mode_num (info[15]) reflects the actual operating state
+        # mode_num (info[10]) only reflects the last configured mode, not power state
+        current_mode_num = self._state.get("current_mode_num")
+        if current_mode_num == 0 and self._state.get("off"):
+            return HVACMode.OFF
         mode_num = self._state.get("mode_num", 0)
         return EASY_MODE_TO_HA_MODE.get(mode_num, HVACMode.OFF)
 

--- a/custom_components/micro_air_easytouch/climate.py
+++ b/custom_components/micro_air_easytouch/climate.py
@@ -117,35 +117,15 @@ class MicroAirEasyTouchClimate(ClimateEntity, RestoreEntity):
         self._last_known_hvac_mode: HVACMode | None = None
 
     async def async_added_to_hass(self) -> None:
-        """Restore last known state on startup so we don't flash 'Off'."""
+        """Restore last known active mode on startup so we don't flash 'Off'."""
         await super().async_added_to_hass()
         last_state = await self.async_get_last_state()
         if last_state and last_state.state not in (STATE_UNAVAILABLE, STATE_UNKNOWN, None):
             try:
                 restored_mode = HVACMode(last_state.state)
-                self._last_known_hvac_mode = restored_mode
-                # Seed _state so temperature and setpoints also survive a restart
-                attrs = last_state.attributes
-                seed = {}
-                for key in (
-                    "current_temperature",
-                    "temperature",
-                    "target_temp_high",
-                    "target_temp_low",
-                ):
-                    if attrs.get(key) is not None:
-                        seed[key] = attrs[key]
-                # Map HA attribute names back to internal keys
-                if "current_temperature" in seed:
-                    self._state["facePlateTemperature"] = seed["current_temperature"]
-                if "temperature" in seed:
-                    if restored_mode == HVACMode.COOL:
-                        self._state["cool_sp"] = seed["temperature"]
-                    elif restored_mode == HVACMode.HEAT:
-                        self._state["heat_sp"] = seed["temperature"]
                 if restored_mode != HVACMode.OFF:
-                    self._state["current_mode_num"] = HA_MODE_TO_EASY_MODE.get(restored_mode, 0)
-                _LOGGER.debug("Restored last known state: mode=%s", restored_mode)
+                    self._last_known_hvac_mode = restored_mode
+                    _LOGGER.debug("Restored last known hvac mode: %s", restored_mode)
             except (ValueError, KeyError):
                 pass
 
@@ -231,20 +211,17 @@ class MicroAirEasyTouchClimate(ClimateEntity, RestoreEntity):
     @property
     def hvac_mode(self) -> HVACMode:
         """Return hvac operation mode."""
-        # current_mode_num (info[15]) is the authoritative live operating mode —
-        # 0 means off, non-zero means running in that mode (3=cool_on, 5=heat_on, …).
-        # Check it first so that a transient PRM "off" flag (value 7 in param) during
-        # a BLE connection/transition does not override a running mode.
-        current_mode_num = self._state.get("current_mode_num")
-        if current_mode_num is not None:
-            if current_mode_num == 0:
-                return HVACMode.OFF
-            return EASY_MODE_TO_HA_MODE.get(current_mode_num, HVACMode.OFF)
-
-        # No current_mode_num yet (state not populated before first poll).
-        # Fall back to PRM flags, then last known mode.
+        # PRM flags are the authoritative power state: 7=off, 15=on.
+        # Check them first so a device reporting ON in PRM but mode=0 in
+        # current_mode_num (transitional state) is not shown as OFF.
         if self._state.get("off") and not self._state.get("on"):
             return HVACMode.OFF
+        current_mode_num = self._state.get("current_mode_num")
+        if current_mode_num == 0 and self._state.get("off"):
+            return HVACMode.OFF
+        if current_mode_num is not None:
+            return EASY_MODE_TO_HA_MODE.get(current_mode_num, HVACMode.OFF)
+        # No state yet (before first poll) — return last known active mode.
         if self._last_known_hvac_mode is not None:
             return self._last_known_hvac_mode
         return HVACMode.OFF

--- a/custom_components/micro_air_easytouch/climate.py
+++ b/custom_components/micro_air_easytouch/climate.py
@@ -193,12 +193,14 @@ class MicroAirEasyTouchClimate(ClimateEntity):
         if self._state.get("off") and not self._state.get("on"):
             return HVACMode.OFF
         # current_mode_num (info[15]) reflects the actual operating state
+        # including active states: 3=cool_on, 5=heat_on
         # mode_num (info[10]) only reflects the last configured mode, not power state
         current_mode_num = self._state.get("current_mode_num")
         if current_mode_num == 0 and self._state.get("off"):
             return HVACMode.OFF
-        mode_num = self._state.get("mode_num", 0)
-        return EASY_MODE_TO_HA_MODE.get(mode_num, HVACMode.OFF)
+        if current_mode_num is not None:
+            return EASY_MODE_TO_HA_MODE.get(current_mode_num, HVACMode.OFF)
+        return HVACMode.OFF
 
     @property
     def hvac_action(self) -> HVACAction | None:

--- a/custom_components/micro_air_easytouch/climate.py
+++ b/custom_components/micro_air_easytouch/climate.py
@@ -259,39 +259,41 @@ class MicroAirEasyTouchClimate(ClimateEntity):
         if not ble_device:
             raise HomeAssistantError("Could not find BLE device")
 
-        changes = {"zone": 0, "power": 1}
+        changes = {}
         if ATTR_TEMPERATURE in kwargs:
             temp = int(kwargs[ATTR_TEMPERATURE])
             if self.hvac_mode == HVACMode.COOL:
                 changes["cool_sp"] = temp
-                # Optimistic update
                 self._state["cool_sp"] = temp
             elif self.hvac_mode == HVACMode.HEAT:
                 changes["heat_sp"] = temp
-                # Optimistic update
                 self._state["heat_sp"] = temp
             elif self.hvac_mode == HVACMode.DRY:
                 changes["dry_sp"] = temp
-                # Optimistic update
                 self._state["dry_sp"] = temp
         elif "target_temp_high" in kwargs and "target_temp_low" in kwargs:
             changes["autoCool_sp"] = int(kwargs["target_temp_high"])
             changes["autoHeat_sp"] = int(kwargs["target_temp_low"])
-            # Optimistic update
             self._state["autoCool_sp"] = int(kwargs["target_temp_high"])
             self._state["autoHeat_sp"] = int(kwargs["target_temp_low"])
 
-        if changes:
-            # Optimistic update - show new state immediately
-            self.async_write_ha_state()
-            
-            message = {"Type": "Change", "Changes": changes}
-            try:
-                if not await self._data.send_command(self.hass, ble_device, message):
-                    raise HomeAssistantError("Failed to set temperature")
-            finally:
-                # Always refresh state from device to correct optimistic update
-                await self._async_fetch_state()
+        if not changes:
+            return
+
+        # Add required fields only when we have actual temperature changes
+        changes["zone"] = 0
+        changes["power"] = 1
+
+        # Optimistic update - show new state immediately
+        self.async_write_ha_state()
+
+        message = {"Type": "Change", "Changes": changes}
+        try:
+            if not await self._data.send_command(self.hass, ble_device, message):
+                raise HomeAssistantError("Failed to set temperature")
+        finally:
+            # Always refresh state from device to correct optimistic update
+            await self._async_fetch_state()
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target hvac mode."""

--- a/custom_components/micro_air_easytouch/climate.py
+++ b/custom_components/micro_air_easytouch/climate.py
@@ -16,12 +16,14 @@ from homeassistant.const import (
     ATTR_TEMPERATURE,
     UnitOfTemperature,
 )
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.components.bluetooth import async_ble_device_from_address
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.restore_state import RestoreEntity
 
 from .const import DOMAIN
 from .micro_air_easytouch.parser import MicroAirEasyTouchBluetoothDeviceData
@@ -46,7 +48,7 @@ async def async_setup_entry(
     entity = MicroAirEasyTouchClimate(data, config_entry.unique_id)
     async_add_entities([entity])
 
-class MicroAirEasyTouchClimate(ClimateEntity):
+class MicroAirEasyTouchClimate(ClimateEntity, RestoreEntity):
     """Representation of MicroAirEasyTouch Climate."""
 
     _attr_has_entity_name = True
@@ -113,6 +115,39 @@ class MicroAirEasyTouchClimate(ClimateEntity):
         )
         self._state = {}
         self._last_known_hvac_mode: HVACMode | None = None
+
+    async def async_added_to_hass(self) -> None:
+        """Restore last known state on startup so we don't flash 'Off'."""
+        await super().async_added_to_hass()
+        last_state = await self.async_get_last_state()
+        if last_state and last_state.state not in (STATE_UNAVAILABLE, STATE_UNKNOWN, None):
+            try:
+                restored_mode = HVACMode(last_state.state)
+                self._last_known_hvac_mode = restored_mode
+                # Seed _state so temperature and setpoints also survive a restart
+                attrs = last_state.attributes
+                seed = {}
+                for key in (
+                    "current_temperature",
+                    "temperature",
+                    "target_temp_high",
+                    "target_temp_low",
+                ):
+                    if attrs.get(key) is not None:
+                        seed[key] = attrs[key]
+                # Map HA attribute names back to internal keys
+                if "current_temperature" in seed:
+                    self._state["facePlateTemperature"] = seed["current_temperature"]
+                if "temperature" in seed:
+                    if restored_mode == HVACMode.COOL:
+                        self._state["cool_sp"] = seed["temperature"]
+                    elif restored_mode == HVACMode.HEAT:
+                        self._state["heat_sp"] = seed["temperature"]
+                if restored_mode != HVACMode.OFF:
+                    self._state["current_mode_num"] = HA_MODE_TO_EASY_MODE.get(restored_mode, 0)
+                _LOGGER.debug("Restored last known state: mode=%s", restored_mode)
+            except (ValueError, KeyError):
+                pass
 
     @property
     def icon(self) -> str:

--- a/custom_components/micro_air_easytouch/climate.py
+++ b/custom_components/micro_air_easytouch/climate.py
@@ -330,54 +330,52 @@ class MicroAirEasyTouchClimate(ClimateEntity):
         if not ble_device:
             raise HomeAssistantError("Could not find BLE device")
 
-        try:
-            # Map standard name to device value
-            if self.hvac_mode == HVACMode.FAN_ONLY:
-                if fan_mode == "off":
-                    fan_value = 0
-                elif fan_mode == "low":
-                    fan_value = 1
-                elif fan_mode == "high":
-                    fan_value = 2
-                else:
-                    fan_value = 0
-                # Optimistic update
-                self._state["fan_mode_num"] = fan_value
-                self.async_write_ha_state()
-                
-                message = {"Type": "Change", "Changes": {"zone": 0, "fanOnly": fan_value}}
-                if not await self._data.send_command(self.hass, ble_device, message):
-                    raise HomeAssistantError(f"Failed to set fan mode to {fan_mode}")
+        # Map standard name to device value and build changes
+        if self.hvac_mode == HVACMode.FAN_ONLY:
+            if fan_mode == "off":
+                fan_value = 0
+            elif fan_mode == "low":
+                fan_value = 1
+            elif fan_mode == "high":
+                fan_value = 2
             else:
-                if fan_mode == "off":
-                    fan_value = 0
-                elif fan_mode == "low":
-                    fan_value = 1  # manualL
-                elif fan_mode == "high":
-                    fan_value = 2  # manualH
-                elif fan_mode == "auto":
-                    fan_value = 128  # full auto
-                else:
-                    fan_value = 128
-                changes = {"zone": 0}
-                if self.hvac_mode == HVACMode.COOL:
-                    changes["coolFan"] = fan_value
-                    # Optimistic update
-                    self._state["cool_fan_mode_num"] = fan_value
-                elif self.hvac_mode == HVACMode.HEAT:
-                    changes["heatFan"] = fan_value
-                    # Optimistic update
-                    self._state["heat_fan_mode_num"] = fan_value
-                elif self.hvac_mode == HVACMode.AUTO:
-                    changes["autoFan"] = fan_value
-                    # Optimistic update
-                    self._state["auto_fan_mode_num"] = fan_value
-                
-                self.async_write_ha_state()
-                
-                message = {"Type": "Change", "Changes": changes}
-                if not await self._data.send_command(self.hass, ble_device, message):
-                    raise HomeAssistantError(f"Failed to set fan mode to {fan_mode}")
+                fan_value = 0
+            changes = {"zone": 0, "fanOnly": fan_value}
+            self._state["fan_mode_num"] = fan_value
+        else:
+            if fan_mode == "off":
+                fan_value = 0
+            elif fan_mode == "low":
+                fan_value = 1  # manualL
+            elif fan_mode == "high":
+                fan_value = 2  # manualH
+            elif fan_mode == "auto":
+                fan_value = 128  # full auto
+            else:
+                fan_value = 128
+            changes = {}
+            if self.hvac_mode == HVACMode.COOL:
+                changes["coolFan"] = fan_value
+                self._state["cool_fan_mode_num"] = fan_value
+            elif self.hvac_mode == HVACMode.HEAT:
+                changes["heatFan"] = fan_value
+                self._state["heat_fan_mode_num"] = fan_value
+            elif self.hvac_mode == HVACMode.AUTO:
+                changes["autoFan"] = fan_value
+                self._state["auto_fan_mode_num"] = fan_value
+
+            if not changes:
+                # OFF or DRY mode - no fan key to set, skip BLE round-trip
+                return
+
+            changes["zone"] = 0
+
+        self.async_write_ha_state()
+
+        message = {"Type": "Change", "Changes": changes}
+        try:
+            if not await self._data.send_command(self.hass, ble_device, message):
+                raise HomeAssistantError(f"Failed to set fan mode to {fan_mode}")
         finally:
             # Always refresh state from device to correct optimistic update
             await self._async_fetch_state()

--- a/custom_components/micro_air_easytouch/climate.py
+++ b/custom_components/micro_air_easytouch/climate.py
@@ -21,6 +21,7 @@ from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.components.bluetooth import async_ble_device_from_address
+from homeassistant.exceptions import HomeAssistantError
 
 from .const import DOMAIN
 from .micro_air_easytouch.parser import MicroAirEasyTouchBluetoothDeviceData
@@ -129,12 +130,11 @@ class MicroAirEasyTouchClimate(ClimateEntity):
         """Return the icon to use for the current fan mode."""
         return self._FAN_MODE_ICONS.get(self.fan_mode, "mdi:fan")
 
-    async def _async_fetch_initial_state(self) -> None:
-        """Fetch the initial state from the device."""
+    async def _async_fetch_state(self) -> None:
+        """Fetch the current state from the device."""
         ble_device = async_ble_device_from_address(self.hass, self._mac_address)
         if not ble_device:
             _LOGGER.error("Could not find BLE device: %s", self._mac_address)
-            self._state = {}
             return
 
         message = {"Type": "Get Status", "Zone": 0, "EM": self._data._email, "TM": int(time.time())}
@@ -142,18 +142,18 @@ class MicroAirEasyTouchClimate(ClimateEntity):
             if await self._data.send_command(self.hass, ble_device, message):
                 json_payload = await self._data._read_gatt_with_retry(self.hass, UUIDS["jsonReturn"], ble_device)
                 if json_payload:
-                    self._state = self._data.decrypt(json_payload.decode('utf-8'))
-                    _LOGGER.debug("Initial state fetched: %s", self._state)
-                    self.async_write_ha_state()
+                    new_state = self._data.decrypt(json_payload.decode('utf-8'))
+                    # Preserve existing state if fetch returns empty/partial data
+                    if new_state:
+                        self._state = new_state
+                        _LOGGER.debug("State fetched: %s", self._state)
+                        self.async_write_ha_state()
                 else:
-                    self._state = {}
-                    _LOGGER.warning("No payload received for initial state")
+                    _LOGGER.warning("No payload received for state fetch")
             else:
-                self._state = {}
-                _LOGGER.warning("Failed to send command for initial state")
+                _LOGGER.warning("Failed to send command for state fetch")
         except Exception as e:
-            _LOGGER.error("Failed to fetch initial state: %s", str(e))
-            self._state = {}
+            _LOGGER.error("Failed to fetch state: %s", str(e))
 
     @property
     def current_temperature(self) -> float | None:
@@ -248,35 +248,53 @@ class MicroAirEasyTouchClimate(ClimateEntity):
         """Set new target temperature."""
         ble_device = async_ble_device_from_address(self.hass, self._mac_address)
         if not ble_device:
-            _LOGGER.error("Could not find BLE device")
-            return
+            raise HomeAssistantError("Could not find BLE device")
 
         changes = {"zone": 0, "power": 1}
         if ATTR_TEMPERATURE in kwargs:
             temp = int(kwargs[ATTR_TEMPERATURE])
             if self.hvac_mode == HVACMode.COOL:
                 changes["cool_sp"] = temp
+                # Optimistic update
+                self._state["cool_sp"] = temp
             elif self.hvac_mode == HVACMode.HEAT:
                 changes["heat_sp"] = temp
+                # Optimistic update
+                self._state["heat_sp"] = temp
             elif self.hvac_mode == HVACMode.DRY:
                 changes["dry_sp"] = temp
+                # Optimistic update
+                self._state["dry_sp"] = temp
         elif "target_temp_high" in kwargs and "target_temp_low" in kwargs:
             changes["autoCool_sp"] = int(kwargs["target_temp_high"])
             changes["autoHeat_sp"] = int(kwargs["target_temp_low"])
+            # Optimistic update
+            self._state["autoCool_sp"] = int(kwargs["target_temp_high"])
+            self._state["autoHeat_sp"] = int(kwargs["target_temp_low"])
 
         if changes:
+            # Optimistic update - show new state immediately
+            self.async_write_ha_state()
+            
             message = {"Type": "Change", "Changes": changes}
-            await self._data.send_command(self.hass, ble_device, message)
+            if not await self._data.send_command(self.hass, ble_device, message):
+                raise HomeAssistantError("Failed to set temperature")
+            
+            # Refresh state from device to confirm
+            await self._async_fetch_state()
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target hvac mode."""
         ble_device = async_ble_device_from_address(self.hass, self._mac_address)
         if not ble_device:
-            _LOGGER.error("Could not find BLE device")
-            return
+            raise HomeAssistantError("Could not find BLE device")
 
         mode = HA_MODE_TO_EASY_MODE.get(hvac_mode)
         if mode is not None:
+            # Optimistic update
+            self._state["mode_num"] = mode
+            self.async_write_ha_state()
+            
             message = {
                 "Type": "Change",
                 "Changes": {
@@ -285,14 +303,17 @@ class MicroAirEasyTouchClimate(ClimateEntity):
                     "mode": mode,
                 },
             }
-            await self._data.send_command(self.hass, ble_device, message)
+            if not await self._data.send_command(self.hass, ble_device, message):
+                raise HomeAssistantError(f"Failed to set HVAC mode to {hvac_mode}")
+            
+            # Refresh state from device to confirm
+            await self._async_fetch_state()
 
     async def async_set_fan_mode(self, fan_mode: str) -> None:
         """Set new target fan mode using standard Home Assistant names."""
         ble_device = async_ble_device_from_address(self.hass, self._mac_address)
         if not ble_device:
-            _LOGGER.error("Could not find BLE device")
-            return
+            raise HomeAssistantError("Could not find BLE device")
 
         # Map standard name to device value
         if self.hvac_mode == HVACMode.FAN_ONLY:
@@ -304,8 +325,13 @@ class MicroAirEasyTouchClimate(ClimateEntity):
                 fan_value = 2
             else:
                 fan_value = 0
+            # Optimistic update
+            self._state["fan_mode_num"] = fan_value
+            self.async_write_ha_state()
+            
             message = {"Type": "Change", "Changes": {"zone": 0, "fanOnly": fan_value}}
-            await self._data.send_command(self.hass, ble_device, message)
+            if not await self._data.send_command(self.hass, ble_device, message):
+                raise HomeAssistantError(f"Failed to set fan mode to {fan_mode}")
         else:
             if fan_mode == "off":
                 fan_value = 0
@@ -320,13 +346,26 @@ class MicroAirEasyTouchClimate(ClimateEntity):
             changes = {"zone": 0}
             if self.hvac_mode == HVACMode.COOL:
                 changes["coolFan"] = fan_value
+                # Optimistic update
+                self._state["cool_fan_mode_num"] = fan_value
             elif self.hvac_mode == HVACMode.HEAT:
                 changes["heatFan"] = fan_value
+                # Optimistic update
+                self._state["heat_fan_mode_num"] = fan_value
             elif self.hvac_mode == HVACMode.AUTO:
                 changes["autoFan"] = fan_value
+                # Optimistic update
+                self._state["auto_fan_mode_num"] = fan_value
+            
+            self.async_write_ha_state()
+            
             message = {"Type": "Change", "Changes": changes}
-            await self._data.send_command(self.hass, ble_device, message)
+            if not await self._data.send_command(self.hass, ble_device, message):
+                raise HomeAssistantError(f"Failed to set fan mode to {fan_mode}")
+        
+        # Refresh state from device to confirm
+        await self._async_fetch_state()
 
     async def async_update(self) -> None:
-        """Update the entity state manually if needed."""
-        await self._async_fetch_initial_state()
+        """Update the entity state from device."""
+        await self._async_fetch_state()

--- a/custom_components/micro_air_easytouch/climate.py
+++ b/custom_components/micro_air_easytouch/climate.py
@@ -277,11 +277,12 @@ class MicroAirEasyTouchClimate(ClimateEntity):
             self.async_write_ha_state()
             
             message = {"Type": "Change", "Changes": changes}
-            if not await self._data.send_command(self.hass, ble_device, message):
-                raise HomeAssistantError("Failed to set temperature")
-            
-            # Refresh state from device to confirm
-            await self._async_fetch_state()
+            try:
+                if not await self._data.send_command(self.hass, ble_device, message):
+                    raise HomeAssistantError("Failed to set temperature")
+            finally:
+                # Always refresh state from device to correct optimistic update
+                await self._async_fetch_state()
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target hvac mode."""
@@ -303,11 +304,12 @@ class MicroAirEasyTouchClimate(ClimateEntity):
                     "mode": mode,
                 },
             }
-            if not await self._data.send_command(self.hass, ble_device, message):
-                raise HomeAssistantError(f"Failed to set HVAC mode to {hvac_mode}")
-            
-            # Refresh state from device to confirm
-            await self._async_fetch_state()
+            try:
+                if not await self._data.send_command(self.hass, ble_device, message):
+                    raise HomeAssistantError(f"Failed to set HVAC mode to {hvac_mode}")
+            finally:
+                # Always refresh state from device to correct optimistic update
+                await self._async_fetch_state()
 
     async def async_set_fan_mode(self, fan_mode: str) -> None:
         """Set new target fan mode using standard Home Assistant names."""
@@ -315,56 +317,57 @@ class MicroAirEasyTouchClimate(ClimateEntity):
         if not ble_device:
             raise HomeAssistantError("Could not find BLE device")
 
-        # Map standard name to device value
-        if self.hvac_mode == HVACMode.FAN_ONLY:
-            if fan_mode == "off":
-                fan_value = 0
-            elif fan_mode == "low":
-                fan_value = 1
-            elif fan_mode == "high":
-                fan_value = 2
+        try:
+            # Map standard name to device value
+            if self.hvac_mode == HVACMode.FAN_ONLY:
+                if fan_mode == "off":
+                    fan_value = 0
+                elif fan_mode == "low":
+                    fan_value = 1
+                elif fan_mode == "high":
+                    fan_value = 2
+                else:
+                    fan_value = 0
+                # Optimistic update
+                self._state["fan_mode_num"] = fan_value
+                self.async_write_ha_state()
+                
+                message = {"Type": "Change", "Changes": {"zone": 0, "fanOnly": fan_value}}
+                if not await self._data.send_command(self.hass, ble_device, message):
+                    raise HomeAssistantError(f"Failed to set fan mode to {fan_mode}")
             else:
-                fan_value = 0
-            # Optimistic update
-            self._state["fan_mode_num"] = fan_value
-            self.async_write_ha_state()
-            
-            message = {"Type": "Change", "Changes": {"zone": 0, "fanOnly": fan_value}}
-            if not await self._data.send_command(self.hass, ble_device, message):
-                raise HomeAssistantError(f"Failed to set fan mode to {fan_mode}")
-        else:
-            if fan_mode == "off":
-                fan_value = 0
-            elif fan_mode == "low":
-                fan_value = 1  # manualL
-            elif fan_mode == "high":
-                fan_value = 2  # manualH
-            elif fan_mode == "auto":
-                fan_value = 128  # full auto
-            else:
-                fan_value = 128
-            changes = {"zone": 0}
-            if self.hvac_mode == HVACMode.COOL:
-                changes["coolFan"] = fan_value
-                # Optimistic update
-                self._state["cool_fan_mode_num"] = fan_value
-            elif self.hvac_mode == HVACMode.HEAT:
-                changes["heatFan"] = fan_value
-                # Optimistic update
-                self._state["heat_fan_mode_num"] = fan_value
-            elif self.hvac_mode == HVACMode.AUTO:
-                changes["autoFan"] = fan_value
-                # Optimistic update
-                self._state["auto_fan_mode_num"] = fan_value
-            
-            self.async_write_ha_state()
-            
-            message = {"Type": "Change", "Changes": changes}
-            if not await self._data.send_command(self.hass, ble_device, message):
-                raise HomeAssistantError(f"Failed to set fan mode to {fan_mode}")
-        
-        # Refresh state from device to confirm
-        await self._async_fetch_state()
+                if fan_mode == "off":
+                    fan_value = 0
+                elif fan_mode == "low":
+                    fan_value = 1  # manualL
+                elif fan_mode == "high":
+                    fan_value = 2  # manualH
+                elif fan_mode == "auto":
+                    fan_value = 128  # full auto
+                else:
+                    fan_value = 128
+                changes = {"zone": 0}
+                if self.hvac_mode == HVACMode.COOL:
+                    changes["coolFan"] = fan_value
+                    # Optimistic update
+                    self._state["cool_fan_mode_num"] = fan_value
+                elif self.hvac_mode == HVACMode.HEAT:
+                    changes["heatFan"] = fan_value
+                    # Optimistic update
+                    self._state["heat_fan_mode_num"] = fan_value
+                elif self.hvac_mode == HVACMode.AUTO:
+                    changes["autoFan"] = fan_value
+                    # Optimistic update
+                    self._state["auto_fan_mode_num"] = fan_value
+                
+                self.async_write_ha_state()
+                
+                message = {"Type": "Change", "Changes": changes}
+                if not await self._data.send_command(self.hass, ble_device, message):
+                    raise HomeAssistantError(f"Failed to set fan mode to {fan_mode}")
+        finally:
+            # Always refresh state from device to correct optimistic update
+            await self._async_fetch_state()
 
     async def async_update(self) -> None:
         """Update the entity state from device."""

--- a/custom_components/micro_air_easytouch/climate.py
+++ b/custom_components/micro_air_easytouch/climate.py
@@ -305,8 +305,14 @@ class MicroAirEasyTouchClimate(ClimateEntity):
 
         mode = HA_MODE_TO_EASY_MODE.get(hvac_mode)
         if mode is not None:
-            # Optimistic update
-            self._state["mode_num"] = mode
+            # Optimistic update — write to the keys hvac_mode actually reads
+            self._state["current_mode_num"] = mode
+            if hvac_mode == HVACMode.OFF:
+                self._state["off"] = True
+                self._state.pop("on", None)
+            else:
+                self._state["on"] = True
+                self._state.pop("off", None)
             self.async_write_ha_state()
             
             message = {

--- a/custom_components/micro_air_easytouch/manifest.json
+++ b/custom_components/micro_air_easytouch/manifest.json
@@ -15,5 +15,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/k3vmcd/ha-micro-air-easytouch/issues",
   "requirements": [],
-  "version": "0.2.0"
+  "version": "0.2.1"
 }

--- a/custom_components/micro_air_easytouch/micro_air_easytouch/const.py
+++ b/custom_components/micro_air_easytouch/micro_air_easytouch/const.py
@@ -10,6 +10,7 @@ UUIDS = {
 }
 
 # Map EasyTouch modes to Home Assistant HVAC modes
+# Note: modes 3 (cool_on) and 5 (heat_on) are active states
 HA_MODE_TO_EASY_MODE = {
     HVACMode.OFF: 0,
     HVACMode.FAN_ONLY: 1,
@@ -18,7 +19,18 @@ HA_MODE_TO_EASY_MODE = {
     HVACMode.DRY: 6,
     HVACMode.AUTO: 11,
 }
-EASY_MODE_TO_HA_MODE = {v: k for k, v in HA_MODE_TO_EASY_MODE.items()}
+
+# Reverse mapping includes active states (3=cool_on, 5=heat_on)
+EASY_MODE_TO_HA_MODE = {
+    0: HVACMode.OFF,
+    1: HVACMode.FAN_ONLY,
+    2: HVACMode.COOL,
+    3: HVACMode.COOL,    # cool_on -> COOL (actively cooling)
+    4: HVACMode.HEAT,
+    5: HVACMode.HEAT,    # heat_on -> HEAT (actively heating)
+    6: HVACMode.DRY,
+    11: HVACMode.AUTO,
+}
 
 # Fan mode mappings (general and mode-specific)
 FAN_MODES_FULL = {


### PR DESCRIPTION
- Add missing HVAC mode mappings for active states (3=cool_on, 5=heat_on) When the furnace/AC is actively running, the device reports modes 3 or 5 which were not mapped, causing HA to show OFF instead of HEAT/COOL

- Add optimistic state updates for immediate UI feedback State is now updated locally before sending commands, then confirmed with a device read after the command completes

- Add state refresh after all commands (set_temperature, set_hvac_mode, set_fan_mode) Previously state was only updated on poll interval, causing sync drift

- Fix memory leak: event listener now properly cancelled on unload The bluetooth_service_info listener was registered but never removed

- Add proper error handling with HomeAssistantError Failed commands now raise exceptions instead of silently failing

- Rename _async_fetch_initial_state to _async_fetch_state (clarity)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cancel Bluetooth event listeners on unload to prevent memory leaks
  * Surface explicit errors when the device is not reachable

* **New Features**
  * Optimistic UI updates for immediate feedback when changing temperature, mode, or fan settings

* **Improvements**
  * Preserve existing state when device data is missing
  * Always refresh device state after control actions to reconcile UI
  * Clarified HVAC mode mappings to handle active cooling/heating consistently
<!-- end of auto-generated comment: release notes by coderabbit.ai -->